### PR TITLE
feat: add support for multifelt data

### DIFF
--- a/src/identity/main.cairo
+++ b/src/identity/main.cairo
@@ -1,9 +1,9 @@
-use core::array::SpanTrait;
 #[starknet::contract]
 mod Identity {
     use starknet::ContractAddress;
     use starknet::contract_address::ContractAddressZeroable;
     use starknet::{get_caller_address, get_contract_address};
+    use starknet::{SyscallResultTrait, StorageBaseAddress};
     use traits::Into;
     use array::{ArrayTrait, SpanTrait};
     use zeroable::Zeroable;
@@ -13,6 +13,10 @@ mod Identity {
     use core::pedersen;
     use debug::PrintTrait;
 
+    const USER_DATA_ADDR: felt252 =
+        1043580099640415304067929596039389735845630832049981224284932480360577081706;
+    const VERIFIER_DATA_ADDR: felt252 =
+        304878986635684253299743444353489138340069571156984851619649640349195152192;
 
     #[storage]
     struct Storage {
@@ -20,6 +24,53 @@ mod Identity {
         user_data: LegacyMap<(u128, felt252), felt252>,
         verifier_data: LegacyMap<(u128, felt252, ContractAddress), felt252>,
         main_id_by_addr: LegacyMap<ContractAddress, u128>,
+    }
+
+    // 
+    // Events
+    // 
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        VerifierDataUpdate: VerifierDataUpdate,
+        ExtendedVerifierDataUpdate: ExtendedVerifierDataUpdate,
+        UserDataUpdate: UserDataUpdate,
+        ExtendedUserDataUpdate: ExtendedUserDataUpdate,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct VerifierDataUpdate {
+        #[key]
+        id: u128,
+        field: felt252,
+        _data: felt252,
+        verifier: ContractAddress,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ExtendedVerifierDataUpdate {
+        #[key]
+        id: u128,
+        field: felt252,
+        _data: Span<felt252>,
+        verifier: ContractAddress,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct UserDataUpdate {
+        #[key]
+        id: u128,
+        field: felt252,
+        _data: felt252,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ExtendedUserDataUpdate {
+        #[key]
+        id: u128,
+        field: felt252,
+        _data: Span<felt252>,
     }
 
     #[constructor]
@@ -36,9 +87,7 @@ mod Identity {
             self.main_id_by_addr.read(user)
         }
 
-        fn get_user_data(
-            self: @ContractState, id: u128, field: felt252, domain: felt252
-        ) -> felt252 {
+        fn get_user_data(self: @ContractState, id: u128, field: felt252, domain: u32) -> felt252 {
             // todo: when volition comes, check on the specified domain
             self.user_data.read((id, field))
         }
@@ -48,18 +97,55 @@ mod Identity {
             self.user_data.read((id, field))
         }
 
+        fn get_extended_user_data(
+            self: @ContractState, id: u128, field: felt252, length: felt252, domain: u32
+        ) -> Span<felt252> {
+            self
+                .get_extended(
+                    USER_DATA_ADDR, array![id.into(), field].span(), 0, length.into(), domain,
+                )
+        }
+
+        fn get_unbounded_user_data(
+            self: @ContractState, id: u128, field: felt252, domain: u32
+        ) -> Span<felt252> {
+            self.get_unbounded(USER_DATA_ADDR, array![id.into(), field].span(), 0, domain,)
+        }
+
 
         fn get_verifier_data(
-            self: @ContractState,
-            id: u128,
-            field: felt252,
-            verifier: ContractAddress,
-            domain: felt252
+            self: @ContractState, id: u128, field: felt252, verifier: ContractAddress, domain: u32
         ) -> felt252 {
             // todo: when volition comes, check on the specified domain
             self.verifier_data.read((id, field, verifier))
         }
 
+        fn get_extended_verifier_data(
+            self: @ContractState,
+            id: u128,
+            field: felt252,
+            length: felt252,
+            verifier: ContractAddress,
+            domain: u32
+        ) -> Span<felt252> {
+            self
+                .get_extended(
+                    VERIFIER_DATA_ADDR,
+                    array![id.into(), field, verifier.into()].span(),
+                    0,
+                    length.into(),
+                    domain,
+                )
+        }
+
+        fn get_unbounded_verifier_data(
+            self: @ContractState, id: u128, field: felt252, verifier: ContractAddress, domain: u32
+        ) -> Span<felt252> {
+            self
+                .get_unbounded(
+                    VERIFIER_DATA_ADDR, array![id.into(), field, verifier.into()].span(), 0, domain,
+                )
+        }
 
         fn get_crosschecked_verifier_data(
             self: @ContractState, id: u128, field: felt252, verifier: ContractAddress
@@ -88,17 +174,164 @@ mod Identity {
         }
 
         fn set_user_data(
-            ref self: ContractState, id: u128, field: felt252, data: felt252, domain: felt252
+            ref self: ContractState, id: u128, field: felt252, data: felt252, domain: u32
         ) {
             // todo: when volition comes, handle the domain
             self.user_data.write((id, field), data);
+            self.emit(Event::UserDataUpdate(UserDataUpdate { id, field, _data: data }))
+        }
+
+        fn set_extended_user_data(
+            ref self: ContractState, id: u128, field: felt252, data: Span<felt252>, domain: u32
+        ) {
+            let caller = get_caller_address();
+            assert(caller == self.owner_by_id.read(id), 'you don\'t own this id');
+            self.set(USER_DATA_ADDR, array![id.into(), field].span(), 0, data, domain);
+            self
+                .emit(
+                    Event::ExtendedUserDataUpdate(
+                        ExtendedUserDataUpdate { id, field, _data: data, }
+                    )
+                );
         }
 
         fn set_verifier_data(
-            ref self: ContractState, id: u128, field: felt252, data: felt252, domain: felt252
+            ref self: ContractState, id: u128, field: felt252, data: felt252, domain: u32
         ) {
             // todo: when volition comes, handle the domain
-            self.verifier_data.write((id, field, get_caller_address()), data);
+            let verifier = get_caller_address();
+            self.verifier_data.write((id, field, verifier), data);
+            self
+                .emit(
+                    Event::VerifierDataUpdate(
+                        VerifierDataUpdate { id, field, _data: data, verifier, }
+                    )
+                )
+        }
+
+        fn set_extended_verifier_data(
+            ref self: ContractState, id: u128, field: felt252, data: Span<felt252>, domain: u32
+        ) {
+            let verifier = get_caller_address();
+            self
+                .set(
+                    VERIFIER_DATA_ADDR,
+                    array![id.into(), field, verifier.into()].span(),
+                    0,
+                    data,
+                    domain
+                );
+            self
+                .emit(
+                    Event::ExtendedVerifierDataUpdate(
+                        ExtendedVerifierDataUpdate { id, field, _data: data, verifier, }
+                    )
+                );
+        }
+    }
+
+    //
+    // Internals
+    //
+
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        // todo: move these functions into a storage contract when components are available
+        fn get_extended(
+            self: @ContractState,
+            fn_name: felt252,
+            params: Span<felt252>,
+            offset: u8,
+            length: felt252,
+            domain: u32
+        ) -> Span<felt252> {
+            let base = self.compute_base_address(fn_name, params);
+            let mut data = ArrayTrait::new();
+            let mut offset = 0;
+            loop {
+                if length == offset.into() {
+                    break ();
+                }
+                let value = self._get(domain, base, offset);
+                data.append(value);
+                offset += 1;
+            };
+            data.span()
+        }
+
+        fn get_unbounded(
+            self: @ContractState, fn_name: felt252, params: Span<felt252>, offset: u8, domain: u32
+        ) -> Span<felt252> {
+            let base = self.compute_base_address(fn_name, params);
+            let mut data = ArrayTrait::new();
+            let mut offset = 0;
+            loop {
+                let value = self._get(domain, base, offset);
+                if value == 0 {
+                    break ();
+                }
+                data.append(value);
+                offset += 1;
+            };
+            data.span()
+        }
+
+        fn _get(
+            self: @ContractState, domain: u32, base: starknet::StorageBaseAddress, offset: u8,
+        ) -> felt252 {
+            starknet::storage_read_syscall(
+                domain, starknet::storage_address_from_base_and_offset(base, offset)
+            )
+                .unwrap_syscall()
+        }
+
+        fn set(
+            ref self: ContractState,
+            fn_name: felt252,
+            params: Span<felt252>,
+            offset: u8,
+            value: Span<felt252>,
+            domain: u32,
+        ) {
+            let base = self.compute_base_address(fn_name, params);
+            self._set(domain, base, value, offset: offset);
+        }
+
+        fn _set(
+            ref self: ContractState,
+            domain: u32,
+            base: starknet::StorageBaseAddress,
+            mut value: Span<felt252>,
+            offset: u8
+        ) {
+            match value.pop_front() {
+                Option::Some(v) => {
+                    starknet::storage_write_syscall(
+                        domain, starknet::storage_address_from_base_and_offset(base, offset), *v
+                    );
+                    self._set(domain, base, value, offset + 1);
+                },
+                Option::None(_) => {},
+            }
+        }
+
+        fn compute_base_address(
+            self: @ContractState, fn_name: felt252, params: Span<felt252>
+        ) -> StorageBaseAddress {
+            let mut _params = params;
+            let mut tmp: felt252 = hash::LegacyHash::hash(
+                fn_name, *_params.pop_front().expect('error computing hash')
+            );
+            loop {
+                if _params.len() == 0 {
+                    break ();
+                }
+                let hash = hash::LegacyHash::hash(
+                    tmp, *_params.pop_front().expect('error computing hash')
+                );
+                tmp = hash;
+            };
+            starknet::storage_base_address_from_felt252(tmp)
         }
     }
 }

--- a/src/interface/identity.cairo
+++ b/src/interface/identity.cairo
@@ -4,13 +4,34 @@ use starknet::ContractAddress;
 trait IIdentity<TContractState> {
     fn owner_of(self: @TContractState, id: u128) -> ContractAddress;
 
-    fn get_user_data(self: @TContractState, id: u128, field: felt252, domain: felt252) -> felt252;
+    fn get_user_data(self: @TContractState, id: u128, field: felt252, domain: u32) -> felt252;
+
+    fn get_extended_user_data(
+        self: @TContractState, id: u128, field: felt252, length: felt252, domain: u32
+    ) -> Span<felt252>;
+
+    fn get_unbounded_user_data(
+        self: @TContractState, id: u128, field: felt252, domain: u32
+    ) -> Span<felt252>;
 
     fn get_crosschecked_user_data(self: @TContractState, id: u128, field: felt252) -> felt252;
 
     fn get_verifier_data(
-        self: @TContractState, id: u128, field: felt252, verifier: ContractAddress, domain: felt252
+        self: @TContractState, id: u128, field: felt252, verifier: ContractAddress, domain: u32
     ) -> felt252;
+
+    fn get_extended_verifier_data(
+        self: @TContractState,
+        id: u128,
+        field: felt252,
+        length: felt252,
+        verifier: ContractAddress,
+        domain: u32
+    ) -> Span<felt252>;
+
+    fn get_unbounded_verifier_data(
+        self: @TContractState, id: u128, field: felt252, verifier: ContractAddress, domain: u32
+    ) -> Span<felt252>;
 
     fn get_crosschecked_verifier_data(
         self: @TContractState, id: u128, field: felt252, verifier: ContractAddress
@@ -27,10 +48,18 @@ trait IIdentity<TContractState> {
     // todo: add support for multifelts data
 
     fn set_user_data(
-        ref self: TContractState, id: u128, field: felt252, data: felt252, domain: felt252
+        ref self: TContractState, id: u128, field: felt252, data: felt252, domain: u32
+    );
+
+    fn set_extended_user_data(
+        ref self: TContractState, id: u128, field: felt252, data: Span<felt252>, domain: u32
     );
 
     fn set_verifier_data(
-        ref self: TContractState, id: u128, field: felt252, data: felt252, domain: felt252
+        ref self: TContractState, id: u128, field: felt252, data: felt252, domain: u32
+    );
+
+    fn set_extended_verifier_data(
+        ref self: TContractState, id: u128, field: felt252, data: Span<felt252>, domain: u32
     );
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,3 +1,4 @@
 mod identity;
 mod interface;
+#[cfg(test)]
 mod tests;

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -1,2 +1,3 @@
 mod test_identity;
+mod test_extended_data;
 mod utils;

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -1,3 +1,4 @@
 mod test_identity;
 mod test_extended_data;
+mod test_addresses_comp;
 mod utils;

--- a/src/tests/test_addresses_comp.cairo
+++ b/src/tests/test_addresses_comp.cairo
@@ -1,0 +1,57 @@
+use starknet::testing;
+use identity::identity::main::Identity;
+use identity::interface::identity::{IIdentity, IIdentityDispatcher, IIdentityDispatcherTrait};
+use debug::PrintTrait;
+use starknet::{SyscallResultTrait, StorageBaseAddress};
+use traits::{Into, TryInto};
+
+const VERIFIER_DATA_ADDR: felt252 =
+    304878986635684253299743444353489138340069571156984851619649640349195152192;
+
+#[test]
+#[available_gas(20000000000)]
+fn test_compute_address_single_param() {
+    let mut unsafe_state = Identity::unsafe_new_contract_state();
+
+    // It should return the same value as utils::get_storage_var_address() from starknet-rs
+    let expected_0 = 0x04496ba66d9685813220a5ba3d7b2be924385ad47abfafeec804b0e2f3f0ec56;
+    let computed_addr_0 = Identity::InternalImpl::compute_base_address(
+        @unsafe_state, VERIFIER_DATA_ADDR, array![0].span()
+    );
+    assert(computed_addr_0 == expected_0, 'Invalid storage address');
+
+    // It should return the same value as utils::get_storage_var_address() from starknet-rs
+    let expected: felt252 = 0x01f65ea3e42f099a1c085eecf45ce0d476a1ab440e3ed539604cac5ba6944258;
+    let computed_addr = Identity::InternalImpl::compute_base_address(
+        @unsafe_state, VERIFIER_DATA_ADDR, array![123].span()
+    );
+    assert(computed_addr == expected, 'Invalid storage address');
+}
+
+
+#[test]
+#[available_gas(20000000000)]
+fn test_compute_address_multiple_params() {
+    let mut unsafe_state = Identity::unsafe_new_contract_state();
+
+    // It should return the same value as utils::get_storage_var_address() from starknet-rs
+    let expected = 0x023289a31298cac4a750e1fbc154c96b5398aa7e94018d9d5c115690aa124767;
+    let computed_addr = Identity::InternalImpl::compute_base_address(
+        @unsafe_state, VERIFIER_DATA_ADDR, array![0, 1, 3].span()
+    );
+    assert(computed_addr == expected, 'Invalid storage address');
+}
+
+
+#[test]
+#[available_gas(20000000000)]
+fn test_compute_address_empty_param() {
+    let mut unsafe_state = Identity::unsafe_new_contract_state();
+
+    // It should return the same value as utils::get_storage_var_address() from starknet-rs
+    let expected = 0x00ac8e2e1fdb949863544c38e1ed04b4c447121f2b60005f7c7f798c6a35ab40;
+    let computed_addr = Identity::InternalImpl::compute_base_address(
+        @unsafe_state, VERIFIER_DATA_ADDR, array![].span()
+    );
+    assert(computed_addr == expected, 'Invalid storage address');
+}

--- a/src/tests/test_extended_data.cairo
+++ b/src/tests/test_extended_data.cairo
@@ -1,0 +1,124 @@
+use array::ArrayTrait;
+use debug::PrintTrait;
+use zeroable::Zeroable;
+use traits::Into;
+use starknet::{ContractAddress, contract_address_const};
+use starknet::testing::set_contract_address;
+use super::utils;
+use identity::interface::identity::{IIdentityDispatcher, IIdentityDispatcherTrait};
+use identity::identity::main::Identity;
+
+fn deploy_identity() -> IIdentityDispatcher {
+    let address = utils::deploy(Identity::TEST_CLASS_HASH, ArrayTrait::<felt252>::new());
+    IIdentityDispatcher { contract_address: address }
+}
+
+#[test]
+#[available_gas(20000000000)]
+fn test_verifier_data() {
+    let identity = deploy_identity();
+    identity.mint(1);
+    let caller = contract_address_const::<0x456>();
+    set_contract_address(caller);
+    identity.set_verifier_data(1, 'starknet', 0x123, 0);
+    assert(identity.get_verifier_data(1, 'starknet', caller, 0) == 0x123, 'wrong data');
+}
+
+#[test]
+#[available_gas(20000000000)]
+fn test_extended_verifier_data() {
+    let identity = deploy_identity();
+    identity.mint(1);
+    let caller = contract_address_const::<0x456>();
+    set_contract_address(caller);
+    identity.set_extended_verifier_data(1, 'starknet', array![0x123, 0x456].span(), 0);
+    assert(
+        identity
+            .get_extended_verifier_data(1, 'starknet', 2, caller, 0) == array![0x123, 0x456]
+            .span(),
+        'wrong data'
+    );
+}
+
+#[test]
+#[available_gas(20000000000)]
+fn test_get_extended_verifier_data_len_1() {
+    // It should test that data written with set_verifier_data is correctly fetched with get_extended_user_data
+    let identity = deploy_identity();
+    identity.mint(1);
+    let caller = contract_address_const::<0x456>();
+    set_contract_address(caller);
+    identity.set_verifier_data(1, 'starknet', 0x123, 0);
+    assert(
+        identity.get_extended_verifier_data(1, 'starknet', 1, caller, 0) == array![0x123].span(),
+        'wrong data'
+    );
+}
+
+#[test]
+#[available_gas(20000000000)]
+fn test_set_extended_verifier_data_len_1() {
+    // It should test that writing extended verifier data of length 1
+    // fetching with get_verifier_data returns the correct value
+    let identity = deploy_identity();
+    identity.mint(1);
+    let caller = contract_address_const::<0x456>();
+    set_contract_address(caller);
+    identity.set_extended_verifier_data(1, 'starknet', array![0x123].span(), 0);
+    assert(identity.get_verifier_data(1, 'starknet', caller, 0) == 0x123, 'wrong data');
+}
+
+#[test]
+#[available_gas(20000000000)]
+fn test_unbounded_verifier_data() {
+    let identity = deploy_identity();
+    identity.mint(1);
+    let caller = contract_address_const::<0x456>();
+    set_contract_address(caller);
+    identity.set_extended_verifier_data(1, 'starknet', array![0x123, 0x456, 0x789].span(), 0);
+    assert(
+        identity
+            .get_unbounded_verifier_data(1, 'starknet', caller, 0) == array![0x123, 0x456, 0x789]
+            .span(),
+        'wrong data'
+    );
+}
+
+#[test]
+#[available_gas(20000000000)]
+fn test_extended_user_data() {
+    let identity = deploy_identity();
+    let caller = contract_address_const::<0x456>();
+    set_contract_address(caller);
+    identity.mint(1);
+    identity.set_extended_user_data(1, 'starknet', array![0x123, 0x456, 0x789].span(), 0);
+    assert(
+        identity.get_extended_user_data(1, 'starknet', 3, 0) == array![0x123, 0x456, 0x789].span(),
+        'wrong data'
+    );
+}
+
+#[test]
+#[available_gas(20000000000)]
+fn test_unbounded_user_data() {
+    let identity = deploy_identity();
+    let caller = contract_address_const::<0x456>();
+    set_contract_address(caller);
+    identity.mint(1);
+    identity.set_extended_user_data(1, 'starknet', array![0x123, 0x456, 0x789].span(), 0);
+    assert(
+        identity.get_unbounded_user_data(1, 'starknet', 0) == array![0x123, 0x456, 0x789].span(),
+        'wrong data'
+    );
+}
+
+#[test]
+#[available_gas(20000000000)]
+#[should_panic(expected: ('you don\'t own this id', 'ENTRYPOINT_FAILED'))]
+fn test_set_user_data_not_owner() {
+    let identity = deploy_identity();
+    identity.mint(1);
+    let caller = contract_address_const::<0x456>();
+    set_contract_address(caller);
+    identity.set_extended_user_data(1, 'starknet', array![0x123, 0x456, 0x789].span(), 0);
+}

--- a/src/tests/test_identity.cairo
+++ b/src/tests/test_identity.cairo
@@ -8,13 +8,11 @@ use super::utils;
 use identity::interface::identity::{IIdentityDispatcher, IIdentityDispatcherTrait};
 use identity::identity::main::Identity;
 
-#[cfg(test)]
 fn deploy_identity() -> IIdentityDispatcher {
     let address = utils::deploy(Identity::TEST_CLASS_HASH, ArrayTrait::<felt252>::new());
     IIdentityDispatcher { contract_address: address }
 }
 
-#[cfg(test)]
 #[test]
 #[available_gas(20000000000)]
 fn test_user_data() {
@@ -25,7 +23,6 @@ fn test_user_data() {
     assert(identity.get_user_data(1, 'starknet', 0) == 0x123, 'wrong data');
 }
 
-#[cfg(test)]
 #[test]
 #[available_gas(20000000000)]
 fn test_verifier_data() {


### PR DESCRIPTION
this PR adds support for multifelt data and adds `set_extended_verifier_data`, `get_extended_verifier_data`, `get_unbounded_verifier_data` & the corresponding functions for user data. 

It also adds the events that are emitted whenever there is an update of verifier data & user data. 