### PR TITLE
feat: add storage_read function

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/starknet-id/identity"
 
 [dependencies]
 starknet = "2.3.0"
-storage_read = { git = "https://github.com/starknet-id/storage_read_component", branch = "master" }
+storage_read = { git = "https://github.com/starknet-id/storage_read_component", rev = "c6c69e15d34abfc39ac51dc21b96724e2e19ff31" }
+custom_uri = { git = "https://github.com/starknet-id/custom_uri_component", rev = "abb2f3d43c7be56dd5cd9f93c33af40b272c2245" }
 
 [[target.starknet-contract]]
 sierra = true

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/starknet-id/identity"
 
 [dependencies]
 starknet = "2.3.0"
+storage_read = { git = "https://github.com/starknet-id/storage_read_component", branch = "master" }
 
 [[target.starknet-contract]]
 sierra = true

--- a/src/identity/main.cairo
+++ b/src/identity/main.cairo
@@ -93,7 +93,6 @@ mod Identity {
 
     #[external(v0)]
     impl IdentityImpl of IIdentity<ContractState> {
-
         fn tokenURI(self: @ContractState, tokenId: u256) -> Array<felt252> {
             self.custom_uri.get_uri(tokenId)
         }

--- a/src/identity/main.cairo
+++ b/src/identity/main.cairo
@@ -12,12 +12,14 @@ mod Identity {
     use integer::{u256_safe_divmod, u256_as_non_zero};
     use core::pedersen;
     use storage_read::{main::storage_read_component, interface::IStorageRead};
+    use custom_uri::{interface::IInternalCustomURI, main::custom_uri_component};
 
     const USER_DATA_ADDR: felt252 =
         1043580099640415304067929596039389735845630832049981224284932480360577081706;
     const VERIFIER_DATA_ADDR: felt252 =
         304878986635684253299743444353489138340069571156984851619649640349195152192;
 
+    component!(path: custom_uri_component, storage: custom_uri, event: CustomUriEvent);
     component!(path: storage_read_component, storage: storage_read, event: StorageReadEvent);
 
     #[abi(embed_v0)]
@@ -29,6 +31,8 @@ mod Identity {
         user_data: LegacyMap<(u128, felt252), felt252>,
         verifier_data: LegacyMap<(u128, felt252, ContractAddress), felt252>,
         main_id_by_addr: LegacyMap<ContractAddress, u128>,
+        #[substorage(v0)]
+        custom_uri: custom_uri_component::Storage,
         #[substorage(v0)]
         storage_read: storage_read_component::Storage,
     }
@@ -44,6 +48,7 @@ mod Identity {
         ExtendedVerifierDataUpdate: ExtendedVerifierDataUpdate,
         UserDataUpdate: UserDataUpdate,
         ExtendedUserDataUpdate: ExtendedUserDataUpdate,
+        CustomUriEvent: custom_uri_component::Event,
         StorageReadEvent: storage_read_component::Event
     }
 
@@ -82,10 +87,17 @@ mod Identity {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState) {}
+    fn constructor(ref self: ContractState, token_uri_base: Span<felt252>,) {
+        self.custom_uri.set_base_uri(token_uri_base);
+    }
 
     #[external(v0)]
     impl IdentityImpl of IIdentity<ContractState> {
+
+        fn tokenURI(self: @ContractState, tokenId: u256) -> Array<felt252> {
+            self.custom_uri.get_uri(tokenId)
+        }
+
         fn owner_of(self: @ContractState, id: u128) -> ContractAddress {
             // todo: when components are ready, use ERC721
             self.owner_by_id.read(id)

--- a/src/interface/identity.cairo
+++ b/src/interface/identity.cairo
@@ -2,6 +2,8 @@ use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IIdentity<TContractState> {
+    fn tokenURI(self: @TContractState, tokenId: u256) -> Array<felt252>;
+
     fn owner_of(self: @TContractState, id: u128) -> ContractAddress;
 
     fn get_user_data(self: @TContractState, id: u128, field: felt252, domain: u32) -> felt252;

--- a/src/tests/test_extended_data.cairo
+++ b/src/tests/test_extended_data.cairo
@@ -9,7 +9,7 @@ use identity::interface::identity::{IIdentityDispatcher, IIdentityDispatcherTrai
 use identity::identity::main::Identity;
 
 fn deploy_identity() -> IIdentityDispatcher {
-    let address = utils::deploy(Identity::TEST_CLASS_HASH, ArrayTrait::<felt252>::new());
+    let address = utils::deploy(Identity::TEST_CLASS_HASH, array![0]);
     IIdentityDispatcher { contract_address: address }
 }
 

--- a/src/tests/test_identity.cairo
+++ b/src/tests/test_identity.cairo
@@ -9,7 +9,7 @@ use identity::interface::identity::{IIdentityDispatcher, IIdentityDispatcherTrai
 use identity::identity::main::Identity;
 
 fn deploy_identity() -> IIdentityDispatcher {
-    let address = utils::deploy(Identity::TEST_CLASS_HASH, ArrayTrait::<felt252>::new());
+    let address = utils::deploy(Identity::TEST_CLASS_HASH, array![0]);
     IIdentityDispatcher { contract_address: address }
 }
 


### PR DESCRIPTION
This pull request adds a storage_read function allowing to read arbitrary data from the smartcontract. This could be useful for someone who wants to build something on top of starknetid that we didn't think about. Could also be useful if we lose ownership of the contract.
It also adds a token_uri to the contract

closes #2 
closes #3 