### PR TITLE
feat: add event for main id updates

### DIFF
--- a/src/identity/main.cairo
+++ b/src/identity/main.cairo
@@ -95,11 +95,17 @@ mod Identity {
         ExtendedUserDataUpdate: ExtendedUserDataUpdate,
         MainIdUpdate: MainIdUpdate,
         // components
+        #[flat]
         CustomUriEvent: custom_uri_component::Event,
+        #[flat]
         StorageReadEvent: storage_read_component::Event,
+        #[flat]
         SRC5Event: SRC5Component::Event,
+        #[flat]
         ERC721Event: ERC721Component::Event,
+        #[flat]
         OwnableEvent: OwnableComponent::Event,
+        #[flat]
         UpgradeableEvent: UpgradeableComponent::Event
     }
 


### PR DESCRIPTION
This adds events to listen to for detecting identity main id. This also flattens event, fixing indexation.