### PR TITLE
Production Release: Finalize admin migration

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -17,6 +17,9 @@ sierra = true
 casm = true
 casm-add-pythonic-hints = true
 
+[tool.voyager]
+my_contract = { path = "src/identity.cairo" }
+
 [lib]
 sierra = true
 casm = false

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -18,7 +18,7 @@ casm = true
 casm-add-pythonic-hints = true
 
 [tool.voyager]
-my_contract = { path = "src/identity.cairo" }
+identity = { path = "src/identity.cairo" }
 
 [lib]
 sierra = true

--- a/src/identity/main.cairo
+++ b/src/identity/main.cairo
@@ -61,8 +61,6 @@ mod Identity {
         user_data: LegacyMap<(u128, felt252), felt252>,
         verifier_data: LegacyMap<(u128, felt252, ContractAddress), felt252>,
         main_id_by_addr: LegacyMap<ContractAddress, u128>,
-        // legacy owner
-        Proxy_admin: felt252,
         #[substorage(v0)]
         storage_read: storage_read_component::Storage,
         #[substorage(v0)]
@@ -311,11 +309,6 @@ mod Identity {
                         ExtendedVerifierDataUpdate { id, field, _data: data, verifier, }
                     )
                 );
-        }
-
-        fn remove_proxy_admin(ref self: ContractState) {
-            self.ownable.assert_only_owner();
-            self.Proxy_admin.write(0);
         }
     }
 }

--- a/src/interface/identity.cairo
+++ b/src/interface/identity.cairo
@@ -60,6 +60,4 @@ trait IIdentity<TContractState> {
     fn set_extended_verifier_data(
         ref self: TContractState, id: u128, field: felt252, data: Span<felt252>, domain: u32
     );
-
-    fn remove_proxy_admin(ref self: TContractState);
 }


### PR DESCRIPTION
The goal of this pull request is to remove `Proxy_admin` which is no longer being used. Identity first needs to be upgraded after performing a call to `remove_proxy_admin`